### PR TITLE
Emit Warning events when scheduling is blocked by missing children

### DIFF
--- a/pkg/core/controller_suite.go
+++ b/pkg/core/controller_suite.go
@@ -468,6 +468,25 @@ func ControllerTestSuite[I InstanceType](
 			Expect(instance.GetAnnotations()[SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
 		})
 
+		It("Emits a MissingChildren warning event", func() {
+			eventReason := func(event *corev1.Event) string {
+				return event.Reason
+			}
+			eventType := func(event *corev1.Event) string {
+				return event.Type
+			}
+			Eventually(func() *corev1.EventList {
+				events := &corev1.EventList{}
+				Expect(m.Client.List(context.TODO(), events)).To(Succeed())
+				return events
+			}, timeout).Should(utils.WithItems(ContainElement(
+				SatisfyAll(
+					WithTransform(eventReason, Equal("MissingChildren")),
+					WithTransform(eventType, Equal(corev1.EventTypeWarning)),
+				),
+			)))
+		})
+
 		Context("And the missing child is created", func() {
 			BeforeEach(func() {
 				expectNoReconciles()
@@ -506,6 +525,25 @@ func ControllerTestSuite[I InstanceType](
 			m.Get(instance, timeout).Should(Succeed())
 			Expect(GetPodTemplate(instance).Spec.SchedulerName).To(Equal(SchedulingDisabledSchedulerName))
 			Expect(instance.GetAnnotations()[SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
+		})
+
+		It("Emits a MissingChildren warning event", func() {
+			eventReason := func(event *corev1.Event) string {
+				return event.Reason
+			}
+			eventType := func(event *corev1.Event) string {
+				return event.Type
+			}
+			Eventually(func() *corev1.EventList {
+				events := &corev1.EventList{}
+				Expect(m.Client.List(context.TODO(), events)).To(Succeed())
+				return events
+			}, timeout).Should(utils.WithItems(ContainElement(
+				SatisfyAll(
+					WithTransform(eventReason, Equal("MissingChildren")),
+					WithTransform(eventType, Equal(corev1.EventTypeWarning)),
+				),
+			)))
 		})
 
 		Context("And the missing child is created with a missing field", func() {

--- a/pkg/core/handler.go
+++ b/pkg/core/handler.go
@@ -107,6 +107,7 @@ func (h *Handler[I]) handlePodController(ctx context.Context, instance I) (recon
 	err = h.checkRequiredChildren(configMaps, secrets, configMapsConfig, secretsConfig)
 	if err != nil {
 		// We are missing children but we added watchers for all children so we are done
+		h.recorder.Eventf(instance, corev1.EventTypeWarning, "MissingChildren", "Scheduling blocked due to missing children: %s", err)
 		return reconcile.Result{}, nil
 	}
 
@@ -169,7 +170,7 @@ func (h *Handler[I]) updatePodController(instance I, dryRun bool, isCreate bool)
 		if isCreate {
 			if !dryRun {
 				log.V(0).Info("Not all required children found yet. Disabling scheduling!", "err", err)
-				h.recorder.Eventf(instance, corev1.EventTypeNormal, "SchedulingDisabled", "Disabled scheduling due to missing children: %s", err)
+				h.recorder.Eventf(instance, corev1.EventTypeWarning, "SchedulingDisabled", "Disabled scheduling due to missing children: %s", err)
 			}
 			disableScheduling(instance)
 		} else {


### PR DESCRIPTION
## Summary

Fixes [wave-k8s/wave#186](https://github.com/wave-k8s/wave/issues/186).

When Wave detects that required ConfigMaps or Secrets are missing or incomplete, it now emits a Kubernetes `Warning` event on the affected Deployment/StatefulSet/DaemonSet, making it easy to diagnose why pods remain Pending.

## Changes

### `pkg/core/handler.go`
- **Reconciler path (`handlePodController`)**: Emit a `Warning` event with reason `MissingChildren` when `checkRequiredChildren` fails. Previously this path was silent.
- **Webhook path (`updatePodController`)**: Change the `SchedulingDisabled` event from `EventTypeNormal` → `EventTypeWarning`, since blocking scheduling is a warning condition.

### `pkg/core/controller_suite.go`
- Added test assertions verifying the `MissingChildren` warning event is emitted in both missing-children scenarios (missing resource, missing key in projection).

## Example Event

```
Warning  MissingChildren  Scheduling blocked due to missing children: not all required children exist: missing required configmap default/my-config
```